### PR TITLE
Log request counts; rename & prettify

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@ ghostdriver.log
 test_screenshots/*
 papukaaniApp/migrations/*
 my
+tags
 ecotones*.csv
 Ecotones*.csv
 big*.csv
+papukaani.log
+papukaani.log.*

--- a/papukaani/config/common.py
+++ b/papukaani/config/common.py
@@ -1,3 +1,5 @@
+import logging
+
 """
 Django settings for papukaani project.
 
@@ -33,7 +35,7 @@ INSTALLED_APPS = (
     'django.contrib.messages',
     'django.contrib.staticfiles',
     'papukaaniApp',
-    'rest_framework'
+    'rest_framework',
 )
 
 MIDDLEWARE_CLASSES = (
@@ -44,6 +46,7 @@ MIDDLEWARE_CLASSES = (
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
     'papukaaniApp.middleware.SessionBasedLocaleMiddleware',
+    'papukaaniApp.middleware.RequestLoggingMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'django.middleware.security.SecurityMiddleware',
@@ -147,11 +150,29 @@ LOGGING = {
         'console': {
             'class': 'logging.StreamHandler',
         },
+        'logfile': {
+            'class': 'logging.handlers.RotatingFileHandler',
+            'filename': 'papukaani.log',
+            'maxBytes': 1024 * 100,
+            'backupCount': 3,
+        },
     },
     'loggers': {
         'django': {
-            'handlers': ['console'],
+            'handlers': ['console', 'logfile'], 
             'level': os.getenv('DJANGO_LOG_LEVEL', 'INFO'),
+        },
+        'papukaaniApp.lajistore_requests_summary' : {
+            'handlers': ['console', 'logfile'],
+            'level': 'DEBUG',
+        },
+        'papukaaniApp.lajistore_requests' : {
+            'handlers': ['console', 'logfile'],
+            'level': 'DEBUG',
+        },
+        'papukaaniApp.requests' : {
+            'handlers': ['logfile'],
+            'level': 'DEBUG',
         },
     },
 }

--- a/papukaaniApp/middleware.py
+++ b/papukaaniApp/middleware.py
@@ -1,12 +1,16 @@
 from django.conf import settings
 from django.utils.cache import patch_vary_headers
 from django.utils import translation
+import logging
+from django.utils import timezone
+
 
 class SessionBasedLocaleMiddleware(object):
     """
     This Middleware saves the desired content language in the user session.
     The SessionMiddleware has to be activated.
     """
+
     def process_request(self, request):
         if not (request.method == 'GET' and 'lang' in request.GET):
             return
@@ -17,8 +21,25 @@ class SessionBasedLocaleMiddleware(object):
         translation.activate(lang_code)
 
     def process_response(self, request, response):
-        patch_vary_headers(response, ('Accept-Language',))
+        patch_vary_headers(response, ('Accept-Language', ))
         if 'Content-Language' not in response:
             response['Content-Language'] = translation.get_language()
         translation.deactivate()
+        return response
+
+
+request_logger = logging.getLogger('papukaaniApp.requests')
+request_logger.setLevel('DEBUG')
+
+
+class RequestLoggingMiddleware(object):
+    def process_request(self, request):
+        request_logger.info('[%s] %s %s' %
+                            (timezone.now().strftime('%Y-%m-%d %H:%M:%S'),
+                             request.method, request.get_full_path()))
+
+    def process_response(self, request, response):
+        request_logger.info('[response to %s %s = %s]' %
+                            (request.method, request.get_full_path(),
+                             str(response.status_code)))
         return response

--- a/papukaaniApp/models_LajiStore/device.py
+++ b/papukaaniApp/models_LajiStore/device.py
@@ -47,17 +47,13 @@ class Device:
         Return currently attached individuals id or None for not currently attached
         :return: ID or None
         '''
-        attached = DeviceIndividual.get_attached_individual(self.id)
-        if attached is None:
+        attachment = DeviceIndividual.get_active_attachment_of_device(self.id)
+        if attachment is None:
             return None
-        return attached['individualID']
+        return attachment['individualID']
 
-    def get_individuals_for_device(self):
-        '''
-        Return all attached individuals id or None for none attached
-        :return: ID or None
-        '''
-        return DeviceIndividual.get_individuals_for_device(self.id)
+    def get_attachments(self):
+        return DeviceIndividual.get_attachments_of_device(self.id)
 
     def is_attached(self):
         return False if self.get_attached_individualid() is None else True

--- a/papukaaniApp/services/deviceindividual_service/DeviceIndividual.py
+++ b/papukaaniApp/services/deviceindividual_service/DeviceIndividual.py
@@ -18,8 +18,8 @@ def attach(deviceID, individualID, timestamp):
     :param individualID:  individual.id
     :param timestamp: time of attachment e.g.'2016-02-11T09:45:58+00:00'
     '''
-    if get_attached_individual(deviceID) is None:
-        if get_attached_device(individualID) is None:
+    if get_active_attachment_of_device(deviceID) is None:
+        if get_active_attachment_of_individual(individualID) is None:
             LajiStoreAPI.post_deviceindividual(
                 deviceID=deviceID,
                 individualID=individualID,
@@ -43,43 +43,27 @@ def detach(deviceID, individualID, timestamp):
             LajiStoreAPI.update_deviceindividual(**attachment)
 
 
-def get_attached_individual(deviceID):
-    '''
-        Return currently attached individuals id or None for not currently attached
-        :return: ID or None
-    '''
-    attachments = get_individuals_for_device(deviceID)
+def get_active_attachment_of_device(deviceID):
+    attachments = get_attachments_of_device(deviceID)
     for attachment in attachments:
         if attachment["removed"] is None:
             return attachment
     return None
 
-def get_attached_device(individualID):
-    '''
-        Return currently attached devices id or None for not currently attached
-        :return: ID or None
-    '''
-    attachments = get_devices_for_individual(individualID)
+def get_active_attachment_of_individual(individualID):
+    attachments = get_attachments_of_individual(individualID)
     for attachment in attachments:
         if attachment["removed"] is None:
             return attachment
     return None
 
 
-def get_devices_for_individual(individualID):
-    '''
-        Return all attached devices for individual
-        :return: List of attachments
-    '''
+def get_attachments_of_individual(individualID):
     individualID = '"' + _URL + _INDIVIDUAL_PATH + "/" + individualID + '"'
     return find(individualID=individualID)
 
 
-def get_individuals_for_device(deviceID):
-    '''
-        Return all attached inviduals for device
-        :return: List of attachments
-    '''
+def get_attachments_of_device(deviceID):
     deviceID = '"' + _URL + _DEVICE_PATH + "/" + deviceID + '"'
     return find(deviceID=deviceID)
 

--- a/papukaaniApp/static/papukaani/js/language.js
+++ b/papukaaniApp/static/papukaani/js/language.js
@@ -1,6 +1,5 @@
 var assert = function(condition, message) { 
   if (!condition) {
-    debugger;
     throw Error("Assert failed" + (typeof message !== "undefined" ? ": " + message : ""));
   }
 };

--- a/papukaaniApp/templates/papukaaniApp/devices.html
+++ b/papukaaniApp/templates/papukaaniApp/devices.html
@@ -12,7 +12,7 @@
 {% endblock %}
 
 {% autoescape off %}
-    {% block body_attr %} onload='init({{ device_json }}, {{ individual_json }}, "{{ csrf_token }}")'{% endblock %}
+    {% block body_attr %} onload='init({{ attachments_of_devices }}, {{ individual_names }}, "{{ csrf_token }}")'{% endblock %}
 {% endautoescape %}
 
 {% block content %}
@@ -46,7 +46,7 @@
                 <td>
                     <select id="individualId">
                       <option disabled selected>{% trans "Valitse kiinnitettävä lintu" %}</option>
-                        {% for individual in selection %}
+                        {% for individual in individuals %}
                             <option value="{{ individual.id }}">{{ individual.nickname }}</option>
                         {% endfor %}
                     </select>

--- a/papukaaniApp/templates/papukaaniApp/individuals.html
+++ b/papukaaniApp/templates/papukaaniApp/individuals.html
@@ -25,7 +25,7 @@
     <form id="new_individual_form" class="form-inline" action='{% url "individuals" %}' method="post">
         {% csrf_token %}
 
-        <input class="form-control" type="text" name="nickname" id="new_individual_nickname" placeholder="Nimi"/>
+        <input class="form-control" type="text" name="nickname" id="new_individual_nickname" placeholder="{% trans Nimi %}"/>
 
         <select class="form-control combobox" name="taxon" id="new_individual_taxon">
             <option></option>

--- a/papukaaniApp/tests/lajistore_object_tests/testDevice.py
+++ b/papukaaniApp/tests/lajistore_object_tests/testDevice.py
@@ -67,10 +67,10 @@ class TestDevice(TestCase):
         A, B = self._create_individuals()
         self.d.attach_to(A.id, "2015-10-10T10:10:10+00:00")
         self.d.attach_to(B.id, "2015-10-10T10:10:10+00:00")
-        individuals = self.d.get_individuals_for_device()
+        attachments = self.d.get_attachments()
 
-        self.assertEquals(len(individuals), 1)
-        self.assertTrue(individuals[0]["removed"] is None)
+        self.assertEquals(len(attachments), 1)
+        self.assertTrue(attachments[0]["removed"] is None)
 
         self._delete_individuals([A, B])
 
@@ -88,7 +88,7 @@ class TestDevice(TestCase):
         A, B = self._create_individuals()
         self.d.attach_to(A.id, "2015-10-10T10:10:10+00:00")
         self.d.detach_from(A.id, "2015-10-10T10:10:10+00:00")
-        individuals = self.d.get_individuals_for_device()
+        individuals = self.d.get_attachments()
         self.assertEquals(len(individuals), 1)
         self.assertTrue(individuals[0]["removed"] is not None)
 
@@ -107,7 +107,7 @@ class TestDevice(TestCase):
         self.d.attach_to(A.id, "2015-10-10T10:10:10+00:00")
         self.d.detach_from(A.id, "2015-10-10T10:10:10+00:01")
         self.d.attach_to(B.id, "2015-10-10T10:10:10+00:02")
-        individuals = self.d.get_individuals_for_device()
+        individuals = self.d.get_attachments()
         self.assertEquals(len(individuals), 2)
 
         self._delete_individuals([A, B])

--- a/papukaaniApp/tests/services/testDeviceIndividual.py
+++ b/papukaaniApp/tests/services/testDeviceIndividual.py
@@ -44,10 +44,10 @@ class testDeviceIndividual(TestCase):
         self.assertEquals(0, len(DeviceIndividual.find()))
         DeviceIndividual.attach(self.D.id, self.I.id, "2015-09-29T14:00:00+03:00")
         self.assertEquals(1, len(DeviceIndividual.find()))
-        self.assertEquals(self.I.id, DeviceIndividual.get_attached_individual(self.D.id)["individualID"])
-        self.assertEquals(self.I.id, DeviceIndividual.get_attached_individual(self.D.id)["individualID"])
-        self.assertEquals("2015-09-29T14:00:00+03:00", DeviceIndividual.get_attached_device(self.I.id)["attached"])
-        self.assertEquals("2015-09-29T14:00:00+03:00", DeviceIndividual.get_attached_device(self.I.id)["attached"])
+        self.assertEquals(self.I.id, DeviceIndividual.get_active_attachment_of_device(self.D.id)["individualID"])
+        self.assertEquals(self.I.id, DeviceIndividual.get_active_attachment_of_device(self.D.id)["individualID"])
+        self.assertEquals("2015-09-29T14:00:00+03:00", DeviceIndividual.get_active_attachment_of_individual(self.I.id)["attached"])
+        self.assertEquals("2015-09-29T14:00:00+03:00", DeviceIndividual.get_active_attachment_of_individual(self.I.id)["attached"])
 
     def testAttachTwo(self):
         self.assertEquals(0, len(DeviceIndividual.find()))
@@ -55,10 +55,10 @@ class testDeviceIndividual(TestCase):
         self.assertEquals(1, len(DeviceIndividual.find()))
         DeviceIndividual.attach(self.D2.id, self.I2.id, "2015-09-29T14:00:00+03:00")
         self.assertEquals(2, len(DeviceIndividual.find()))
-        self.assertEquals(self.I.id, DeviceIndividual.get_attached_individual(self.D.id)["individualID"])
-        self.assertEquals(self.D.id, DeviceIndividual.get_attached_device(self.I.id)["deviceID"])
-        self.assertEquals(self.I2.id, DeviceIndividual.get_attached_individual(self.D2.id)["individualID"])
-        self.assertEquals(self.D2.id, DeviceIndividual.get_attached_device(self.I2.id)["deviceID"])
+        self.assertEquals(self.I.id, DeviceIndividual.get_active_attachment_of_device(self.D.id)["individualID"])
+        self.assertEquals(self.D.id, DeviceIndividual.get_active_attachment_of_individual(self.I.id)["deviceID"])
+        self.assertEquals(self.I2.id, DeviceIndividual.get_active_attachment_of_device(self.D2.id)["individualID"])
+        self.assertEquals(self.D2.id, DeviceIndividual.get_active_attachment_of_individual(self.I2.id)["deviceID"])
 
     def testAttachTwiceDoesNotAttachAgain(self):
         self.assertEquals(0, len(DeviceIndividual.find()))
@@ -85,18 +85,18 @@ class testDeviceIndividual(TestCase):
         DeviceIndividual.attach(self.D.id, self.I.id, "2015-09-29T14:00:00+03:00")
 
         self.assertEquals(1, len(DeviceIndividual.find()))
-        self.assertEquals(self.I.id, DeviceIndividual.get_attached_individual(self.D.id)["individualID"])
-        self.assertEquals(self.D.id, DeviceIndividual.get_attached_device(self.I.id)["deviceID"])
-        self.assertEquals(None, DeviceIndividual.get_attached_individual(self.D.id)["removed"])
-        self.assertEquals(None, DeviceIndividual.get_attached_device(self.I.id)["removed"])
+        self.assertEquals(self.I.id, DeviceIndividual.get_active_attachment_of_device(self.D.id)["individualID"])
+        self.assertEquals(self.D.id, DeviceIndividual.get_active_attachment_of_individual(self.I.id)["deviceID"])
+        self.assertEquals(None, DeviceIndividual.get_active_attachment_of_device(self.D.id)["removed"])
+        self.assertEquals(None, DeviceIndividual.get_active_attachment_of_individual(self.I.id)["removed"])
 
         DeviceIndividual.detach(self.D.id, self.I.id, "2015-09-29T14:00:00+03:00")
 
-        self.assertEquals("2015-09-29T14:00:00+03:00", DeviceIndividual.get_individuals_for_device(self.D.id)[0]["removed"])
-        self.assertEquals("2015-09-29T14:00:00+03:00", DeviceIndividual.get_devices_for_individual(self.I.id)[0]["removed"])
+        self.assertEquals("2015-09-29T14:00:00+03:00", DeviceIndividual.get_attachments_of_device(self.D.id)[0]["removed"])
+        self.assertEquals("2015-09-29T14:00:00+03:00", DeviceIndividual.get_attachments_of_individual(self.I.id)[0]["removed"])
         self.assertEquals(1, len(DeviceIndividual.find()))
-        self.assertEquals(None, DeviceIndividual.get_attached_individual(self.D.id))
-        self.assertEquals(None, DeviceIndividual.get_attached_device(self.I.id))
+        self.assertEquals(None, DeviceIndividual.get_active_attachment_of_device(self.D.id))
+        self.assertEquals(None, DeviceIndividual.get_active_attachment_of_individual(self.I.id))
 
     def testAttachDetachTwo(self):
         self.assertEquals(0, len(DeviceIndividual.find()))
@@ -105,22 +105,22 @@ class testDeviceIndividual(TestCase):
         DeviceIndividual.attach(self.D2.id, self.I2.id, "2015-09-29T14:00:00+03:00")
 
         self.assertEquals(2, len(DeviceIndividual.find()))
-        self.assertEquals(self.I.id, DeviceIndividual.get_attached_individual(self.D.id)["individualID"])
-        self.assertEquals(self.D.id, DeviceIndividual.get_attached_device(self.I.id)["deviceID"])
-        self.assertEquals(self.I2.id, DeviceIndividual.get_attached_individual(self.D2.id)["individualID"])
-        self.assertEquals(self.D2.id, DeviceIndividual.get_attached_device(self.I2.id)["deviceID"])
+        self.assertEquals(self.I.id, DeviceIndividual.get_active_attachment_of_device(self.D.id)["individualID"])
+        self.assertEquals(self.D.id, DeviceIndividual.get_active_attachment_of_individual(self.I.id)["deviceID"])
+        self.assertEquals(self.I2.id, DeviceIndividual.get_active_attachment_of_device(self.D2.id)["individualID"])
+        self.assertEquals(self.D2.id, DeviceIndividual.get_active_attachment_of_individual(self.I2.id)["deviceID"])
 
         DeviceIndividual.detach(self.D.id, self.I.id, "2015-09-29T14:00:00+03:00")
 
-        self.assertEquals(None, DeviceIndividual.get_attached_individual(self.D.id))
-        self.assertEquals(None, DeviceIndividual.get_attached_device(self.I.id))
-        self.assertEquals(self.I2.id, DeviceIndividual.get_attached_individual(self.D2.id)["individualID"])
-        self.assertEquals(self.D2.id, DeviceIndividual.get_attached_device(self.I2.id)["deviceID"])
+        self.assertEquals(None, DeviceIndividual.get_active_attachment_of_device(self.D.id))
+        self.assertEquals(None, DeviceIndividual.get_active_attachment_of_individual(self.I.id))
+        self.assertEquals(self.I2.id, DeviceIndividual.get_active_attachment_of_device(self.D2.id)["individualID"])
+        self.assertEquals(self.D2.id, DeviceIndividual.get_active_attachment_of_individual(self.I2.id)["deviceID"])
 
         DeviceIndividual.detach(self.D2.id, self.I2.id, "2015-09-29T14:00:00+03:00")
 
-        self.assertEquals(None, DeviceIndividual.get_attached_individual(self.D2.id))
-        self.assertEquals(None, DeviceIndividual.get_attached_device(self.I2.id))
+        self.assertEquals(None, DeviceIndividual.get_active_attachment_of_device(self.D2.id))
+        self.assertEquals(None, DeviceIndividual.get_active_attachment_of_individual(self.I2.id))
         self.assertEquals(2, len(DeviceIndividual.find()))
 
     def testGetAllAttachedIndividuals(self):
@@ -130,18 +130,18 @@ class testDeviceIndividual(TestCase):
         DeviceIndividual.detach(self.D.id, self.I.id, "2015-09-29T14:00:00+03:00")
         DeviceIndividual.attach(self.D.id, self.I2.id, "2015-09-29T14:00:00+03:00")
 
-        self.assertEquals(2, len(DeviceIndividual.get_individuals_for_device(self.D.id)))
-        self.assertEquals(self.I2.id, DeviceIndividual.get_attached_individual(self.D.id)["individualID"])
+        self.assertEquals(2, len(DeviceIndividual.get_attachments_of_device(self.D.id)))
+        self.assertEquals(self.I2.id, DeviceIndividual.get_active_attachment_of_device(self.D.id)["individualID"])
 
     def testDeletedDevicesDontStopNewAttachments(self):
         DeviceIndividual.attach(self.D.id, self.I.id, "2015-09-29T14:00:00+03:00")
         self.D.delete();
         DeviceIndividual.attach(self.D2.id, self.I.id, "2015-09-29T14:00:00+03:00")
-        self.assertEquals(self.D2.id, DeviceIndividual.get_attached_device(self.I.id)['deviceID'])
+        self.assertEquals(self.D2.id, DeviceIndividual.get_active_attachment_of_individual(self.I.id)['deviceID'])
 
     def testDeletedIndividualsDontStopNewAttachments(self):
         DeviceIndividual.attach(self.D.id, self.I.id, "2015-09-29T14:00:00+03:00")
         self.I.delete();
         DeviceIndividual.attach(self.D.id, self.I2.id, "2015-09-29T14:00:00+03:00")
-        self.assertEquals(self.I2.id, DeviceIndividual.get_attached_individual(self.D.id)['individualID'])
+        self.assertEquals(self.I2.id, DeviceIndividual.get_active_attachment_of_device(self.D.id)['individualID'])
 

--- a/papukaaniApp/utils/view_utils.py
+++ b/papukaaniApp/utils/view_utils.py
@@ -1,5 +1,8 @@
 from django.shortcuts import redirect
 
+ALL_METHOD_NAMES = ['GET', 'HEAD', 'POST', 'PUT', 'DELETE', 'TRACE', 'OPTIONS',
+                    'CONNECT', 'PATCH']
+
 
 def redirect_with_param(to, param):
     response = redirect(to)
@@ -8,5 +11,6 @@ def redirect_with_param(to, param):
 
 
 def extract_latlongs(points):
-    latlongs = [[float(mapPoint.latitude), float(mapPoint.longitude)] for mapPoint in points]
+    latlongs = [[float(mapPoint.latitude), float(mapPoint.longitude)]
+                for mapPoint in points]
     return latlongs

--- a/papukaaniApp/views/decorators.py
+++ b/papukaaniApp/views/decorators.py
@@ -1,0 +1,36 @@
+import logging
+import queue
+from papukaaniApp.utils.view_utils import ALL_METHOD_NAMES
+
+
+def count_lajistore_requests(old_view):
+    def new_view(request, *args, **kwargs):
+        summary_logger = logging.getLogger(
+            'papukaaniApp.lajistore_requests_summary')
+        full_logger = logging.getLogger('papukaaniApp.lajistore_requests')
+
+        q = queue.Queue()
+        h = logging.handlers.QueueHandler(q)
+        requests_logger = logging.getLogger('requests.packages.urllib3')
+        requests_logger.addHandler(h)
+        requests_logger.setLevel('DEBUG')
+        assert q.qsize() == 0
+
+        response = old_view(request, *args, **kwargs)
+
+        num_requests = 0
+        while q.qsize() > 0:
+            r = q.get()
+            word_1 = r.msg.strip('"').split(' ', 1)[0]
+            if word_1 in ALL_METHOD_NAMES:
+                full_logger.info('Made request: %s' % r.msg.strip('"'))
+                num_requests += 1
+
+        msg = 'Made %s requests while serving %s' % (str(num_requests),
+                                                     request.get_full_path())
+        summary_logger.info(msg)
+        requests_logger.removeHandler(h)
+
+        return response
+
+    return new_view

--- a/papukaaniApp/views/device_views.py
+++ b/papukaaniApp/views/device_views.py
@@ -4,25 +4,24 @@ import json
 from rest_framework.decorators import api_view
 from rest_framework.response import Response
 from papukaaniApp.services.laji_auth_service.require_auth import require_auth
+from papukaaniApp.views.decorators import count_lajistore_requests
 
-
+@count_lajistore_requests
 @require_auth
 def devices(request):
     devices = device.find()
     devices.sort(key=lambda x: x.id)
     individuals = individual.find_exclude_deleted()
 
-    # Directory, where key is deviceId and value is an array of individual data
-    individuals_of_devices = {dev.id: dev.get_individuals_for_device() for dev in devices}
+    attachments_of_devices = {dev.id: dev.get_attachments() for dev in devices}
 
-    # Directory, where key is individualId and value is it's name (taxon)
     individual_names = {indiv.id: indiv.nickname for indiv in individuals}
 
     context = {
-        'selection': individuals,
+        'individuals': individuals,
         'devices': devices,
-        'device_json': json.dumps(individuals_of_devices),
-        'individual_json': json.dumps(individual_names)
+        'attachments_of_devices': json.dumps(attachments_of_devices),
+        'individual_names': json.dumps(individual_names)
     }
 
     return render(request, 'papukaaniApp/devices.html', context)
@@ -31,6 +30,7 @@ def devices(request):
 _RESPONSE_BASE = {"errors": [], "status": ""}
 
 
+@count_lajistore_requests
 @api_view(['POST'])
 @require_auth
 def attach_to(request, device_id):
@@ -52,6 +52,7 @@ def attach_to(request, device_id):
     return Response(response)
 
 
+@count_lajistore_requests
 @api_view(['POST'])
 @require_auth
 def remove_from(request, device_id):

--- a/papukaaniApp/views/individual_views.py
+++ b/papukaaniApp/views/individual_views.py
@@ -4,11 +4,13 @@ from django.shortcuts import render
 
 from papukaaniApp.models_LajiStore import individual
 from papukaaniApp.models_TipuApi import species
+from papukaaniApp.views.decorators import count_lajistore_requests
 
 from django.contrib import messages
 
 from django.utils.translation import ugettext_lazy as _
 
+@count_lajistore_requests
 @require_auth
 def individuals(request):
     """

--- a/papukaaniApp/views/public_views.py
+++ b/papukaaniApp/views/public_views.py
@@ -8,8 +8,9 @@ from papukaaniApp.utils.view_utils import extract_latlongs
 from django.views.decorators.clickjacking import xframe_options_exempt
 from papukaaniApp.models_LajiStore import *
 from papukaaniApp.views.login_view import *
+from papukaaniApp.views.decorators import count_lajistore_requests
 
-
+@count_lajistore_requests
 @xframe_options_exempt  # Allows the view to be loaded in an iFrame
 def public(request):
     """


### PR DESCRIPTION
Renamed some functions to be more accurate and less confusing, for example `get_attached_individual` to `get_active_attachment_of_device` and `get_devices_for_individual` to `get_attachments_of_individual`.

For logging, now you see output like:

```
[29/Feb/2016 18:10:24] "GET /papukaani/ HTTP/1.1" 200 2696
Made request: GET /devices HTTP/1.1" 200 None
Made request: GET /individuals HTTP/1.1" 200 None
Made request: GET /deviceIndividuals?q=deviceID:%22https://lajistore.laji.fi/devices/73695%22 HTTP/1.1" 200 None
Made request: GET /devices HTTP/1.1" 200 None
Made request: GET /individuals HTTP/1.1" 200 None
Made request: GET /deviceIndividuals?q=deviceID:%22https://lajistore.laji.fi/devices/73991%22 HTTP/1.1" 200 None
Made request: GET /devices HTTP/1.1" 200 None
Made request: GET /individuals HTTP/1.1" 200 None
Made request: GET /deviceIndividuals?q=deviceID:%22https://lajistore.laji.fi/devices/73994%22 HTTP/1.1" 200 None
Made request: GET /devices HTTP/1.1" 200 None
Made request: GET /individuals HTTP/1.1" 200 None
Made request: GET /deviceIndividuals?q=deviceID:%22https://lajistore.laji.fi/devices/73996%22 HTTP/1.1" 200 None
Made request: GET /devices HTTP/1.1" 200 None
Made request: GET /individuals HTTP/1.1" 200 None
Made request: GET /deviceIndividuals?q=deviceID:%22https://lajistore.laji.fi/devices/74725%22 HTTP/1.1" 200 None
Made request: GET /devices HTTP/1.1" 200 None
Made request: GET /individuals HTTP/1.1" 200 None
Made request: GET /deviceIndividuals?q=deviceID:%22https://lajistore.laji.fi/devices/74726%22 HTTP/1.1" 200 None
Made request: GET /devices HTTP/1.1" 200 None
Made request: GET /individuals HTTP/1.1" 200 None
Made request: GET /deviceIndividuals?q=deviceID:%22https://lajistore.laji.fi/devices/74727%22 HTTP/1.1" 200 None
Made request: GET /devices HTTP/1.1" 200 None
Made request: GET /individuals HTTP/1.1" 200 None
Made request: GET /deviceIndividuals?q=deviceID:%22https://lajistore.laji.fi/devices/74737%22 HTTP/1.1" 200 None
Made request: GET /devices HTTP/1.1" 200 None
Made request: GET /individuals HTTP/1.1" 200 None
Made request: GET /deviceIndividuals?q=deviceID:%22https://lajistore.laji.fi/devices/74738%22 HTTP/1.1" 200 None
Made request: GET /devices HTTP/1.1" 200 None
Made request: GET /individuals HTTP/1.1" 200 None
Made request: GET /deviceIndividuals?q=deviceID:%22https://lajistore.laji.fi/devices/74739%22 HTTP/1.1" 200 None
Made request: GET /devices HTTP/1.1" 200 None
Made request: GET /individuals HTTP/1.1" 200 None
Made request: GET /deviceIndividuals?q=deviceID:%22https://lajistore.laji.fi/devices/74740%22 HTTP/1.1" 200 None
Made request: GET /devices HTTP/1.1" 200 None
Made request: GET /individuals HTTP/1.1" 200 None
Made 35 requests while serving /papukaani/devices/
[29/Feb/2016 18:10:40] "GET /papukaani/devices/ HTTP/1.1" 200 11305
```
